### PR TITLE
Bugfix: Correct Darwin version number for macOS 15.0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -224,7 +224,7 @@ choose_xnu() {
         RELEASE_URL='https://raw.githubusercontent.com/apple-oss-distributions/distribution-macOS/macos-150/release.json'
         KDK_NAME='Kernel Debug Kit 15.0 build 24A335'
         KDKROOT='/Library/Developer/KDKs/KDK_15.0_24A335.kdk'
-        RC_DARWIN_KERNEL_VERSION='24.4.0'
+        RC_DARWIN_KERNEL_VERSION='24.0.0'
         ;;
     *)
         error "Invalid xnu version"


### PR DESCRIPTION
macOS 15.0's (`xnu-11215.1.10`'s) Darwin version number is 24.0.0, not 24.4.0.