### PR TITLE
Use nullglob in bash to avoid matching empty globs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,7 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+shopt -s nullglob
 if [[ "${TRACE-0}" == "1" ]]; then
     set -o xtrace
 fi


### PR DESCRIPTION
Otherwise:

```bash
for SCRIPT in "${PATCH_DIR}"/*.sh; do
    running "Running script: ${SCRIPT}"
    bash "${SCRIPT}"
done
```

will run the body with `SCRIPT='"${PATCH_DIR}"/*.sh'` when there are no shell files.