### PR TITLE
disable BTI (fixes #22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,6 @@ Currently `MACHINE_CONFIG=T8103` is not correctly building for at least `14.3`
 > [!NOTE]
 > When attempting to boot try adding the boot-arg: `sudo nvram boot-args="-unsafe_kernel_text"`
 
-> [!WARNING]
-> Booting VMAPPLE kernels in VMs only works on Apple M1s [see issue](https://github.com/blacktop/darwin-xnu-build/issues/22)
-
 ## Why? 🤔
 
 I'm hoping to patch and build the xnu source in interesting ways to aid in research and development of macOS/iOS security research tools as well as generate [CodeQL](https://securitylab.github.com/tools/codeql) databases for the community to use.

--- a/patches/15.0/disable_bti.patch
+++ b/patches/15.0/disable_bti.patch
@@ -1,0 +1,16 @@
+diff --git a/pexpert/pexpert/arm64/apple_arm64_common.h b/pexpert/pexpert/arm64/apple_arm64_common.h
+index 56caa9556..460c4c4cc 100644
+--- a/pexpert/pexpert/arm64/apple_arm64_common.h
++++ b/pexpert/pexpert/arm64/apple_arm64_common.h
+@@ -89,11 +89,4 @@
+ #define CPU_VERSION_C0                       0x20
+ #define CPU_VERSION_UNKNOWN                  0xff
+ 
+-
+-/*
+- * Conservatively assume that BTI will be enforced.
+- * Individual SoCs and kernel configurations may have different behavior.
+- */
+-#define BTI_ENFORCED 1
+-
+ #endif /* !_PEXPERT_ARM64_APPLE_ARM64_COMMON_H */


### PR DESCRIPTION
Resolves #22 - see attached image

<img width="2512" height="1724" alt="mac15_6_m4" src="https://github.com/user-attachments/assets/870ddf65-8783-4ed2-9f4b-f4990bc99687" />

The reason why XNU booted on M1 but not M2+ is because of BTI, which only exists on M2 and newer chips. The open source kernel throws some BTI faults very early into boot, which only causes problems on hardware where BTI exists.

If you just disable BTI entirely everything works fine